### PR TITLE
Fix pytest warnings for unknown 'integration' mark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ lint = "ruff"
 pythonpath = [
   "src"
 ]
+markers = [
+    "integration: marks tests as integration tests",
+]
 
 
 [dependency-groups]


### PR DESCRIPTION
Registered the 'integration' mark in pyproject.toml to remove warnings during the test run.