### PR TITLE
feat(ci): add test coverage reporting (#48)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
       id: pdm-install
       run: |
         pdm install -G dev
-    - name: Run tests
+    - name: Run tests with coverage
       run: |
-        pdm run test
+        pdm run test --cov=src --cov-report=xml
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true


### PR DESCRIPTION
This commit modifies the GitHub Actions workflow to:
- Generate a test coverage report using pytest-cov.
- Upload the coverage report to Codecov.