### PR TITLE
Fix Codecov upload error by using OIDC (#50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
 
     steps:
@@ -29,7 +31,7 @@ jobs:
       run: |
         pdm run test --cov=src --cov-report=xml
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        use_oidc: true
         fail_ci_if_error: true


### PR DESCRIPTION
The Codecov action was failing with the error "Token required - not valid tokenless upload". This was because the `CODECOV_TOKEN` secret was not configured in the repository.

This commit fixes the issue by upgrading the `codecov/codecov-action` from `v4` to `v5` and switching to OIDC for authentication. This is the recommended approach as it's more secure and doesn't require storing secrets.

The following changes were made to `.github/workflows/ci.yml`:
- Upgraded `codecov/codecov-action` to `v5`.
- Added `permissions: id-token: write` to the `test` job.
- Replaced the `token` input with `use_oidc: true`.